### PR TITLE
use 0.5 instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,7 +7,7 @@ libsteinspanner = library_dependency("libsteinspanner",
 
 provides(SimpleBuild,
    (@build_steps begin
-        ChangeDirectory(joinpath(Pkg.dir("SteinDiscrepancy"), "src/discrepancy/spanner"))
+        ChangeDirectory(joinpath(dirname(@__FILE__), "../src/discrepancy/spanner"))
         MakeTargets(["libstein_spanner.so"])
     end), libsteinspanner, os = :Unix)
 


### PR DESCRIPTION
release will change over time, but since REQUIRE says this package supports
julia 0.5, that should continue to be tested
